### PR TITLE
Add simple Supabase demo pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ npx http-server -p 8080
 
 Then open `http://localhost:8080/main/index.html` in your browser.
 
+### Using VS Code Live Server
+
+If you use Visual Studio Code, you can serve the site with the **Live Server** extension:
+
+1. Install the extension called `Live Server` from the VS Code marketplace.
+2. Open the `voca-2` folder in VS Code.
+3. Right click on any HTML file (for example `simple/login.html`) and choose **Open with Live Server**.
+4. Your browser will open on a local URL (usually `http://127.0.0.1:5500`). Navigate between the pages from there.
+
+Using Live Server is convenient during development because it reloads the page automatically when files are changed.
+
 ### 2. Configure Supabase
 
 1. Create a project on [Supabase](https://supabase.com/).
@@ -39,6 +50,16 @@ All authentication pages are located in the `auth` directory. After starting the
 
 - `http://localhost:8080/auth/auth-sign-up.html`
 - `http://localhost:8080/auth/auth-sign-in.html`
+
+### 4. Simple Example Pages
+
+For a minimal demo using Supabase, open the files in the `simple` directory. These pages contain very small forms that read and write data to Supabase:
+
+- `voca-2/simple/signup.html`
+- `voca-2/simple/login.html`
+- `voca-2/simple/vocabulary.html`
+- `voca-2/simple/symbols.html`
+- `voca-2/simple/formulas.html`
 
 ## Project Structure
 

--- a/voca-2/js/data.js
+++ b/voca-2/js/data.js
@@ -1,0 +1,37 @@
+import { supabase } from './supabase.js';
+
+export async function addVocabulary(word, definition) {
+  const { data, error } = await supabase.from('vocabulary').insert({ word, definition });
+  if (error) throw error;
+  return data;
+}
+
+export async function getVocabulary() {
+  const { data, error } = await supabase.from('vocabulary').select('*').order('id');
+  if (error) throw error;
+  return data;
+}
+
+export async function addSymbol(symbol, value) {
+  const { data, error } = await supabase.from('symbols').insert({ symbol, value });
+  if (error) throw error;
+  return data;
+}
+
+export async function getSymbols() {
+  const { data, error } = await supabase.from('symbols').select('*').order('id');
+  if (error) throw error;
+  return data;
+}
+
+export async function addFormula(formula, description) {
+  const { data, error } = await supabase.from('formulas').insert({ formula, description });
+  if (error) throw error;
+  return data;
+}
+
+export async function getFormulas() {
+  const { data, error } = await supabase.from('formulas').select('*').order('id');
+  if (error) throw error;
+  return data;
+}

--- a/voca-2/simple/forgot-password.html
+++ b/voca-2/simple/forgot-password.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Forgot Password</title>
+</head>
+<body>
+  <h1>Forgot Password</h1>
+  <form id="forgot-form">
+    <input id="email" type="email" placeholder="Email" required>
+    <button type="submit">Send Reset Link</button>
+  </form>
+  <p id="message"></p>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { resetPassword } from '../js/auth.js';
+
+    document.getElementById('forgot-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const email = document.getElementById('email').value.trim();
+      const msg = document.getElementById('message');
+      msg.textContent = '';
+      try {
+        const { success, error } = await resetPassword(email);
+        if (success) {
+          msg.textContent = 'Check your inbox for reset link.';
+        } else {
+          msg.textContent = error;
+        }
+      } catch(err) {
+        console.error(err);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/voca-2/simple/formulas.html
+++ b/voca-2/simple/formulas.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Formulas</title>
+</head>
+<body>
+  <h1>Formulas</h1>
+  <form id="formula-form">
+    <input id="formula" placeholder="Formula" required>
+    <input id="description" placeholder="Description" required>
+    <button type="submit">Add</button>
+  </form>
+  <ul id="formula-list"></ul>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { addFormula, getFormulas } from '../js/data.js';
+
+    async function load() {
+      try {
+        const data = await getFormulas();
+        const list = document.getElementById('formula-list');
+        list.innerHTML = '';
+        data.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = `${item.formula}: ${item.description}`;
+          list.appendChild(li);
+        });
+      } catch(err) {
+        console.error(err);
+      }
+    }
+
+    document.getElementById('formula-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const formula = document.getElementById('formula').value.trim();
+      const description = document.getElementById('description').value.trim();
+      if (!formula || !description) return;
+      try {
+        await addFormula(formula, description);
+        e.target.reset();
+        load();
+      } catch(err) {
+        console.error(err);
+      }
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/voca-2/simple/login.html
+++ b/voca-2/simple/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="login-form">
+    <input id="email" type="email" placeholder="Email" required>
+    <input id="password" type="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <p><a href="forgot-password.html">Forgot password?</a></p>
+  <p>Don't have an account? <a href="signup.html">Sign Up</a></p>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { signIn } from '../js/auth.js';
+
+    document.getElementById('login-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      try {
+        const { success, error } = await signIn(email, password);
+        if (success) {
+          window.location.href = 'vocabulary.html';
+        } else {
+          alert(error);
+        }
+      } catch(err) {
+        console.error(err);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/voca-2/simple/reset-password.html
+++ b/voca-2/simple/reset-password.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Reset Password</title>
+</head>
+<body>
+  <h1>Reset Password</h1>
+  <form id="reset-form">
+    <input id="password" type="password" placeholder="New Password" required>
+    <button type="submit">Update Password</button>
+  </form>
+  <p id="message"></p>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { supabase } from '../js/supabase.js';
+
+    let sessionSet = false;
+
+    async function init() {
+      const params = new URLSearchParams(window.location.hash.slice(1));
+      const access = params.get('access_token');
+      const refresh = params.get('refresh_token');
+      if (access && refresh) {
+        const { error } = await supabase.auth.setSession({ access_token: access, refresh_token: refresh });
+        if (!error) sessionSet = true;
+      }
+    }
+
+    document.getElementById('reset-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      if (!sessionSet) {
+        document.getElementById('message').textContent = 'Invalid or expired link';
+        return;
+      }
+      const password = document.getElementById('password').value;
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        document.getElementById('message').textContent = error.message;
+      } else {
+        document.getElementById('message').textContent = 'Password updated. Please login.';
+        window.location.href = 'login.html';
+      }
+    });
+
+    init();
+  </script>
+</body>
+</html>

--- a/voca-2/simple/signup.html
+++ b/voca-2/simple/signup.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sign Up</title>
+</head>
+<body>
+  <h1>Sign Up</h1>
+  <form id="signup-form">
+    <input id="email" type="email" placeholder="Email" required>
+    <input id="password" type="password" placeholder="Password" required>
+    <button type="submit">Sign Up</button>
+  </form>
+  <p>Already have an account? <a href="login.html">Login</a></p>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { signUp } from '../js/auth.js';
+
+    document.getElementById('signup-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      try {
+        const { success, error } = await signUp(email, password, {});
+        if (success) {
+          alert('Check your email for confirmation');
+          window.location.href = 'login.html';
+        } else {
+          alert(error);
+        }
+      } catch(err) {
+        console.error(err);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/voca-2/simple/symbols.html
+++ b/voca-2/simple/symbols.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Symbols</title>
+</head>
+<body>
+  <h1>Symbols</h1>
+  <form id="symbol-form">
+    <input id="symbol" placeholder="Symbol" required>
+    <input id="value" placeholder="Value" required>
+    <button type="submit">Add</button>
+  </form>
+  <ul id="symbol-list"></ul>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { addSymbol, getSymbols } from '../js/data.js';
+
+    async function load() {
+      try {
+        const data = await getSymbols();
+        const list = document.getElementById('symbol-list');
+        list.innerHTML = '';
+        data.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = `${item.symbol}: ${item.value}`;
+          list.appendChild(li);
+        });
+      } catch(err) {
+        console.error(err);
+      }
+    }
+
+    document.getElementById('symbol-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const symbol = document.getElementById('symbol').value.trim();
+      const value = document.getElementById('value').value.trim();
+      if (!symbol || !value) return;
+      try {
+        await addSymbol(symbol, value);
+        e.target.reset();
+        load();
+      } catch(err) {
+        console.error(err);
+      }
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/voca-2/simple/vocabulary.html
+++ b/voca-2/simple/vocabulary.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vocabulary</title>
+</head>
+<body>
+  <h1>Vocabulary</h1>
+  <form id="vocab-form">
+    <input id="word" placeholder="Word" required>
+    <input id="definition" placeholder="Definition" required>
+    <button type="submit">Add</button>
+  </form>
+  <ul id="vocab-list"></ul>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script type="module">
+    import { addVocabulary, getVocabulary } from '../js/data.js';
+
+    async function load() {
+      try {
+        const data = await getVocabulary();
+        const list = document.getElementById('vocab-list');
+        list.innerHTML = '';
+        data.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = `${item.word}: ${item.definition}`;
+          list.appendChild(li);
+        });
+      } catch(err) {
+        console.error(err);
+      }
+    }
+
+    document.getElementById('vocab-form').addEventListener('submit', async e => {
+      e.preventDefault();
+      const word = document.getElementById('word').value.trim();
+      const definition = document.getElementById('definition').value.trim();
+      if (!word || !definition) return;
+      try {
+        await addVocabulary(word, definition);
+        e.target.reset();
+        load();
+      } catch(err) {
+        console.error(err);
+      }
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/voca-2/supabase/migrations/20240101_create_vocab_symbols_tables.sql
+++ b/voca-2/supabase/migrations/20240101_create_vocab_symbols_tables.sql
@@ -1,0 +1,11 @@
+create table if not exists public.vocabulary (
+  id bigserial primary key,
+  word text not null,
+  definition text not null
+);
+
+create table if not exists public.symbols (
+  id bigserial primary key,
+  symbol text not null,
+  value text not null
+);


### PR DESCRIPTION
## Summary
- add lightweight demo pages under `voca-2/simple` for vocabulary, symbols, formulas and auth
- provide small JS module `data.js` for CRUD helpers
- include migration file to create `vocabulary` and `symbols` tables
- document using Live Server and reference the demo pages in the README

## Testing
- `git status --short`